### PR TITLE
docs: add MOSA adapter boundary note (interface-only)

### DIFF
--- a/docs/reference/mosa_adapter_boundary.md
+++ b/docs/reference/mosa_adapter_boundary.md
@@ -82,3 +82,4 @@ The adapter accepts delegation/revocation signals from the authority chain. Thes
 - The adapter is platform-agnostic and hull-vendor independent
 - All integration points are described at the input/output level
 - No specific GFI ICD version is assumed — adapter pattern is generic
+- This adapter defines interface structures only and does not implement policy evaluation or decision logic


### PR DESCRIPTION
## Scope

Single-scope PR: **MOSA adapter boundary note** (1-page interface-only doc).

### Changes
- `docs/reference/mosa_adapter_boundary.md`: boundary-level interface description
  - Architecture position (wrapper/augmenter around autonomy stacks)
  - Inputs from GFI ICD/API patterns
  - Outputs (decisions, receipts, reason codes, audit logs)
  - Integration points (gate position, receipt emission, log mapping, delegation)

### Constraints
- Interface-only: no implementation details, no proprietary algorithms
- Platform-agnostic, hull-vendor independent
- MANIFEST.md entry to follow
- Ready for cherry-pick into sendmedown/interop-lab

### Context
Per ALPV DIU submission (Task 3 of 3): MOSA adapter boundary note.